### PR TITLE
Correção view quantidade

### DIFF
--- a/resources/views/detalhes.blade.php
+++ b/resources/views/detalhes.blade.php
@@ -11,7 +11,7 @@
         Descrição: R$ {{$p->descricao or 'não tem descrição'}}
     </li>
     <li>
-        Quantidade em estoque: R$ {{$p->quantidade}}
+        Quantidade em estoque: {{$p->quantidade}}
     </li>
 </ul>
 @stop


### PR DESCRIPTION
Simples correção na visualização da quantidade em estoque de um produto onde a exibição aparecia com R$ ao lado.

Antes:
Quantidade em estoque: R$ 4

Depois:
Quantidade em estoque:  4